### PR TITLE
fix: size partial sell retries from remaining position

### DIFF
--- a/backend/service/trades.py
+++ b/backend/service/trades.py
@@ -564,14 +564,34 @@ class Trades:
             return 0
 
     async def get_token_amount_from_trades(self, symbol: str) -> float:
-        """Return total token amount for a symbol."""
+        """Return the net remaining token amount for a symbol."""
         try:
             result = (
                 await model.Trades.filter(symbol=symbol)
                 .annotate(total_amount=Sum(F("amount")))
                 .values_list("total_amount", flat=True)
             )
-            return float(result[0] or 0.0)
+            total_amount = float(result[0] or 0.0)
+            open_trade_rows = (
+                await model.OpenTrades.filter(symbol=symbol)
+                .limit(1)
+                .values(
+                    "amount",
+                    "sold_amount",
+                    "unsellable_amount",
+                    "unsellable_reason",
+                )
+            )
+            open_trade = open_trade_rows[0] if open_trade_rows else None
+            if open_trade:
+                unsellable_state = self._extract_unsellable_state(open_trade)
+                if unsellable_state["is_unsellable"]:
+                    return float(open_trade.get("amount") or total_amount)
+
+                partial_sell = self._normalize_partial_sell_execution(open_trade)
+                total_amount -= partial_sell["sold_amount"]
+
+            return max(0.0, total_amount)
         except BaseORMException as e:
             # Broad catch to avoid crashing on database aggregation errors.
             logging.error("Error getting total amount from %s. Cause %s", symbol, e)

--- a/backend/tests/test_orders_partial_sell_retry.py
+++ b/backend/tests/test_orders_partial_sell_retry.py
@@ -1,0 +1,79 @@
+import os
+
+import model
+import pytest
+from service.orders import Orders
+from tortoise import Tortoise
+
+
+@pytest.mark.asyncio
+async def test_receive_sell_order_uses_remaining_amount_after_partial_fill(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(os.path.join(os.path.dirname(__file__), ".."))
+    db_path = tmp_path / "test.sqlite"
+    await Tortoise.init(db_url=f"sqlite://{db_path}", modules={"models": ["model"]})
+    await Tortoise.generate_schemas()
+
+    await model.Trades.create(
+        timestamp="1777990000000",
+        ordersize=12.1075,
+        fee=0.001,
+        precision=3,
+        amount=725.0,
+        amount_fee=0.0,
+        price=0.0167,
+        symbol="SENT/USDC",
+        orderid="base-1",
+        bot="asap_SENT/USDC",
+        ordertype="market",
+        baseorder=True,
+        safetyorder=False,
+        order_count=0,
+        so_percentage=None,
+        direction="long",
+        side="buy",
+    )
+    await model.OpenTrades.create(
+        symbol="SENT/USDC",
+        sold_amount=608.0,
+        sold_proceeds=10.1536,
+    )
+
+    orders = Orders()
+    submitted_orders: list[dict[str, float | str | bool]] = []
+
+    async def fake_create_spot_sell(order, _config):
+        submitted_orders.append(dict(order))
+        return {
+            "type": "partial_sell",
+            "symbol": order["symbol"],
+            "partial_filled_amount": 0.0,
+            "partial_proceeds": 0.0,
+            "remaining_amount": float(order["total_amount"]),
+        }
+
+    async def fake_close() -> None:
+        return None
+
+    monkeypatch.setattr(orders.exchange, "create_spot_sell", fake_create_spot_sell)
+    monkeypatch.setattr(orders.exchange, "close", fake_close)
+
+    await orders.receive_sell_order(
+        {
+            "symbol": "SENT/USDC",
+            "direction": "long",
+            "side": "sell",
+            "type_sell": "order_sell",
+            "actual_pnl": 0.0,
+            "total_cost": 12.1075,
+            "current_price": 0.0167,
+            "skip_tp_limit_cancel": True,
+        },
+        {},
+    )
+
+    assert len(submitted_orders) == 1
+    assert float(submitted_orders[0]["total_amount"]) == pytest.approx(117.0)
+
+    await Tortoise.close_connections()

--- a/backend/tests/test_trades_amounts.py
+++ b/backend/tests/test_trades_amounts.py
@@ -106,6 +106,49 @@ async def test_get_partial_sell_execution_reads_open_trade_totals(
 
 
 @pytest.mark.asyncio
+async def test_get_token_amount_from_trades_subtracts_partial_sell_totals(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(os.path.join(os.path.dirname(__file__), ".."))
+    db_path = tmp_path / "test.sqlite"
+    await Tortoise.init(db_url=f"sqlite://{db_path}", modules={"models": ["model"]})
+    await Tortoise.generate_schemas()
+
+    import model
+
+    await model.Trades.create(
+        timestamp="1",
+        ordersize=12.1075,
+        fee=0.001,
+        precision=3,
+        amount=725.0,
+        amount_fee=0.0,
+        price=0.0167,
+        symbol="SENT/USDC",
+        orderid="oid1",
+        bot="bot",
+        ordertype="market",
+        baseorder=True,
+        safetyorder=False,
+        order_count=0,
+        so_percentage=None,
+        direction="long",
+        side="buy",
+    )
+    await model.OpenTrades.create(
+        symbol="SENT/USDC",
+        sold_amount=608.0,
+        sold_proceeds=10.1536,
+    )
+
+    trades = Trades()
+    total_amount = await trades.get_token_amount_from_trades("SENT/USDC")
+
+    assert total_amount == pytest.approx(117.0)
+    await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
 async def test_get_trades_for_orders_uses_unsellable_open_trade_amounts(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- fix sell retry sizing to use the net remaining token amount after persisted partial fills
- preserve the existing unsellable-remainder behavior while subtracting `OpenTrades.sold_amount`
- add regressions for both the trade aggregation helper and the retry sell path

## Root cause
Moonwalker persisted partial fills on `OpenTrades.sold_amount`, but `Trades.get_token_amount_from_trades()` still summed only buy-side `Trades.amount`. That made later sell retries submit the original full amount instead of the remainder.

## Verification
- `cd /private/tmp/moonwalker-main-backport/scripts && ./ci.sh`
