### PR TITLE
fix: backport proactive TP remaining-amount sizing

### DIFF
--- a/backend/service/dca.py
+++ b/backend/service/dca.py
@@ -172,6 +172,9 @@ class Dca:
         actual_pnl: float,
     ) -> bool:
         """Place a proactive TP limit order at the exact TP price."""
+        sellable_amount = float(
+            trades.get("sellable_amount") or trades.get("total_amount") or 0.0
+        )
         order = {
             "symbol": trades["symbol"],
             "direction": trades["direction"],
@@ -180,7 +183,7 @@ class Dca:
             "sell_reason": "take_profit_prearm",
             "actual_pnl": actual_pnl,
             "total_cost": trades["total_cost"],
-            "total_amount": trades["total_amount"],
+            "total_amount": sellable_amount,
             "current_price": current_price,
             "limit_price": take_profit_price,
             "tp_price": take_profit_price,
@@ -457,13 +460,16 @@ class Dca:
         if await self.orders.reconcile_tp_limit_order(trades, self.config or {}):
             return
 
+        sellable_amount = float(
+            trades.get("sellable_amount") or trades.get("total_amount") or 0.0
+        )
         has_tp_limit_order = bool(trades.get("tp_limit_order_id"))
         if has_tp_limit_order and (
             not prearm_supported
             or self.__tp_limit_order_outdated(
                 trades,
                 tp_price=take_profit_price,
-                total_amount=float(trades["total_amount"]),
+                total_amount=sellable_amount,
             )
         ):
             canceled = await self.orders.cancel_tp_limit_order(

--- a/backend/service/trades.py
+++ b/backend/service/trades.py
@@ -61,6 +61,35 @@ class Trades:
         }
 
     @staticmethod
+    def _float_or_zero(value: Any) -> float:
+        """Return a finite float or zero for partially-populated trade payloads."""
+        try:
+            parsed = float(value or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+        return parsed if parsed == parsed else 0.0
+
+    @classmethod
+    def _calculate_sellable_amount(
+        cls,
+        *,
+        total_amount: float,
+        open_trade: dict[str, Any] | None,
+    ) -> float:
+        """Return the currently sellable amount after partial-sell bookkeeping."""
+        if not open_trade:
+            return max(0.0, total_amount)
+
+        unsellable_state = cls._extract_unsellable_state(open_trade)
+        if unsellable_state["is_unsellable"]:
+            return max(
+                0.0, cls._float_or_zero(open_trade.get("amount") or total_amount)
+            )
+
+        partial_sell = cls._normalize_partial_sell_execution(open_trade)
+        return max(0.0, total_amount - partial_sell["sold_amount"])
+
+    @staticmethod
     def _extract_unsellable_state(
         open_trade: dict[str, Any] | None,
     ) -> UnsellableTradeState:
@@ -583,15 +612,10 @@ class Trades:
                 )
             )
             open_trade = open_trade_rows[0] if open_trade_rows else None
-            if open_trade:
-                unsellable_state = self._extract_unsellable_state(open_trade)
-                if unsellable_state["is_unsellable"]:
-                    return float(open_trade.get("amount") or total_amount)
-
-                partial_sell = self._normalize_partial_sell_execution(open_trade)
-                total_amount -= partial_sell["sold_amount"]
-
-            return max(0.0, total_amount)
+            return self._calculate_sellable_amount(
+                total_amount=total_amount,
+                open_trade=open_trade,
+            )
         except BaseORMException as e:
             # Broad catch to avoid crashing on database aggregation errors.
             logging.error("Error getting total amount from %s. Cause %s", symbol, e)
@@ -643,18 +667,24 @@ class Trades:
 
             safetyorders_count = len(safetyorders)
             unsellable_state = self._extract_unsellable_state(open_trade)
+            sellable_amount = self._calculate_sellable_amount(
+                total_amount=total_amount,
+                open_trade=open_trade,
+            )
 
             # For unsellable remnants, OpenTrades carries the authoritative
             # remaining amount/cost after partial close bookkeeping.
             if unsellable_state["is_unsellable"] and open_trade:
                 total_amount = float(open_trade.get("amount") or total_amount)
                 total_cost = float(open_trade.get("cost") or total_cost)
+                sellable_amount = total_amount
 
             trade_data = {
                 "timestamp": latest_order["timestamp"],
                 "fee": latest_order["fee"],
                 "total_cost": total_cost,
                 "total_amount": total_amount,
+                "sellable_amount": sellable_amount,
                 "symbol": latest_order["symbol"],
                 "direction": latest_order["direction"],
                 "side": latest_order["side"],

--- a/backend/tests/test_dca_tp_spike_confirmation.py
+++ b/backend/tests/test_dca_tp_spike_confirmation.py
@@ -10,6 +10,7 @@ def _build_trades() -> dict[str, object]:
         "direction": "long",
         "total_cost": 100.0,
         "total_amount": 1.0,
+        "sellable_amount": 1.0,
         "fee": 0.0,
         "timestamp": 1_742_000_000_000,
         "safetyorders_count": 0,
@@ -211,6 +212,7 @@ async def test_tp_limit_prearm_arms_before_tp_when_near(monkeypatch) -> None:
     assert arm_calls[0]["symbol"] == "XPL/USDC"
     assert arm_calls[0]["limit_price"] == pytest.approx(110.0)
     assert arm_calls[0]["fallback_min_price"] == pytest.approx(110.0)
+    assert arm_calls[0]["total_amount"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio
@@ -295,3 +297,64 @@ async def test_tp_limit_prearm_waits_for_existing_order_at_tp(monkeypatch) -> No
 
     assert stat_payloads[-1]["sell"] is False
     assert stat_payloads[-1]["tp_limit_order_armed"] is True
+
+
+@pytest.mark.asyncio
+async def test_tp_limit_prearm_rearms_existing_order_with_remaining_sellable_amount(
+    monkeypatch,
+) -> None:
+    dca = Dca()
+    _configure_dca(
+        dca,
+        sell_order_type="limit",
+        tp_spike_confirm_enabled=False,
+        tp_limit_prearm_enabled=True,
+        tp_limit_prearm_margin_percent=0.25,
+    )
+    trades = _build_trades()
+    trades.update(
+        {
+            "total_amount": 1.0,
+            "sellable_amount": 0.4,
+            "tp_limit_order_id": "tp-1",
+            "tp_limit_order_price": 110.0,
+            "tp_limit_order_amount": 1.0,
+        }
+    )
+    cancel_calls: list[str] = []
+    arm_calls: list[dict[str, object]] = []
+
+    async def fake_reconcile_tp_limit_order(_trades, _config) -> bool:
+        return False
+
+    async def fake_cancel_tp_limit_order(symbol, _config) -> bool:
+        cancel_calls.append(symbol)
+        return True
+
+    async def fake_arm_tp_limit_order(order, _config) -> bool:
+        arm_calls.append(order)
+        return True
+
+    async def fake_update_statistic_data(_payload) -> None:
+        return None
+
+    monkeypatch.setattr(
+        dca.orders,
+        "reconcile_tp_limit_order",
+        fake_reconcile_tp_limit_order,
+    )
+    monkeypatch.setattr(
+        dca.orders,
+        "cancel_tp_limit_order",
+        fake_cancel_tp_limit_order,
+    )
+    monkeypatch.setattr(dca.orders, "arm_tp_limit_order", fake_arm_tp_limit_order)
+    monkeypatch.setattr(
+        dca.statistic, "update_statistic_data", fake_update_statistic_data
+    )
+
+    await dca._Dca__calculate_tp(109.8, trades, _build_policy())
+
+    assert cancel_calls == ["XPL/USDC"]
+    assert len(arm_calls) == 1
+    assert arm_calls[0]["total_amount"] == pytest.approx(0.4)

--- a/backend/tests/test_trades_amounts.py
+++ b/backend/tests/test_trades_amounts.py
@@ -77,6 +77,7 @@ async def test_get_trades_for_orders_uses_net_amount(tmp_path, monkeypatch) -> N
 
     assert aggregated is not None
     assert aggregated["total_amount"] == 99.0
+    assert aggregated["sellable_amount"] == 99.0
     await Tortoise.close_connections()
 
 
@@ -145,6 +146,52 @@ async def test_get_token_amount_from_trades_subtracts_partial_sell_totals(
     total_amount = await trades.get_token_amount_from_trades("SENT/USDC")
 
     assert total_amount == pytest.approx(117.0)
+    await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
+async def test_get_trades_for_orders_exposes_remaining_sellable_amount_after_partial_sell(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(os.path.join(os.path.dirname(__file__), ".."))
+    db_path = tmp_path / "test.sqlite"
+    await Tortoise.init(db_url=f"sqlite://{db_path}", modules={"models": ["model"]})
+    await Tortoise.generate_schemas()
+
+    import model
+
+    await model.Trades.create(
+        timestamp="1",
+        ordersize=12.1075,
+        fee=0.001,
+        precision=3,
+        amount=88.3,
+        amount_fee=0.0,
+        price=0.1372,
+        symbol="ERA/USDC",
+        orderid="oid1",
+        bot="bot",
+        ordertype="market",
+        baseorder=True,
+        safetyorder=False,
+        order_count=0,
+        so_percentage=None,
+        direction="long",
+        side="buy",
+    )
+    await model.OpenTrades.create(
+        symbol="ERA/USDC",
+        sold_amount=76.6,
+        sold_proceeds=10.50952,
+    )
+
+    trades = Trades()
+    aggregated = await trades.get_trades_for_orders("ERA/USDC")
+
+    assert aggregated is not None
+    assert aggregated["total_amount"] == pytest.approx(88.3)
+    assert aggregated["sellable_amount"] == pytest.approx(11.7)
+    assert aggregated["total_cost"] == pytest.approx(12.1075)
     await Tortoise.close_connections()
 
 


### PR DESCRIPTION
## Summary
- backport the proactive TP remaining-amount sizing fix onto main
- expose `sellable_amount` in trade aggregation so proactive TP re-arms do not reuse the original bought size after partial sells
- add regressions for trade aggregation and proactive TP re-arming on the main-based branch

## Testing
- ./.venv/bin/pytest backend/tests/test_trades_amounts.py backend/tests/test_dca_tp_spike_confirmation.py backend/tests/test_orders_partial_sell_retry.py
- cd scripts && ./ci.sh