### PR TITLE
fix: restore Waiting replay strategy indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Moonwalker are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Waiting campaign TradingView replays now resolve the persisted sidestep
+  campaign execution timeline so the strategy indicators used by prior legs
+  render even when the current flat Waiting deal has no executions.
+
 ## [4.3.0.1] - 2026-07-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ base orders, and plain-language trust signals in the Control Center.
   waiting state, and later re-enter that same campaign instead of treating it
   as a brand-new trade.
 - Waiting campaign rows expand into the same TradingView replay used by open
-  and closed trades, with buy, re-entry, safety-order, and exit markers. Sparse
-  legacy campaigns fall back to their campaign and last-exit context.
+  and closed trades, with strategy indicators plus buy, re-entry, safety-order,
+  and exit markers. Sparse legacy campaigns fall back to their campaign and
+  last-exit context.
 - Supported config writes and dashboard snapshots now use `trade_mode` only.
   Older stored rows and backup payloads can still be canonicalized during load
   and restore, but operator workflows should not use the removed bridge keys.

--- a/backend/controller/trades.py
+++ b/backend/controller/trades.py
@@ -197,9 +197,15 @@ async def closed_trades_pagination(
 
 
 @get(path="/trades/executions/{deal_id:str}")
-async def trade_executions(deal_id: FromPath[str]) -> dict[str, Any]:
-    """Get execution rows for one trade deal."""
-    response = await trades.get_trade_executions(deal_id)
+async def trade_executions(
+    deal_id: FromPath[str],
+    campaign_id: FromQuery[str | None] = None,
+) -> dict[str, Any]:
+    """Get execution rows for one trade deal or its sidestep campaign."""
+    response = await trades.get_trade_executions(
+        deal_id,
+        campaign_id=campaign_id,
+    )
     return {"result": response}
 
 
@@ -211,6 +217,7 @@ async def trade_replay_indicator_series(
     timerange: FromPath[str],
     start: FromPath[str],
     end: FromPath[str],
+    campaign_id: FromQuery[str | None] = None,
 ) -> dict[str, Any]:
     """Get strategy indicator overlays for one trade replay chart."""
     response = await trade_replay_indicators.get_indicators(
@@ -218,6 +225,7 @@ async def trade_replay_indicator_series(
         timerange,
         start,
         end,
+        campaign_id=campaign_id,
     )
     return {"result": response}
 

--- a/backend/service/trade_replay_indicators.py
+++ b/backend/service/trade_replay_indicators.py
@@ -1,4 +1,4 @@
-"""Strategy indicator overlays for open and closed trade replay charts."""
+"""Strategy indicator overlays for open, waiting, and closed trade replay charts."""
 
 from __future__ import annotations
 
@@ -88,10 +88,15 @@ class TradeReplayIndicatorService:
         timerange: str,
         timestamp_start: str | int | float,
         timestamp_end: str | int | float,
+        *,
+        campaign_id: str | None = None,
     ) -> dict[str, Any]:
         """Return strategy indicator overlays for a replay deal."""
         try:
             normalized_deal_id = str(UUID(str(deal_id)))
+            normalized_campaign_id = (
+                str(UUID(str(campaign_id))) if campaign_id else None
+            )
             start_ms = int(float(timestamp_start))
             end_ms = int(float(timestamp_end))
         except (TypeError, ValueError):
@@ -100,7 +105,13 @@ class TradeReplayIndicatorService:
         if end_ms <= start_ms:
             return self._empty(timerange)
 
-        executions = await self.trades.get_trade_executions(normalized_deal_id)
+        if normalized_campaign_id:
+            executions = await self.trades.get_trade_executions(
+                normalized_deal_id,
+                campaign_id=normalized_campaign_id,
+            )
+        else:
+            executions = await self.trades.get_trade_executions(normalized_deal_id)
         strategies = self._execution_strategies(executions)
         source = "execution_ledger"
         if not strategies:

--- a/backend/service/trades.py
+++ b/backend/service/trades.py
@@ -692,20 +692,38 @@ class Trades:
             logging.error("Error getting closed orders. Cause: %s", e)
             return []
 
-    async def get_trade_executions(self, deal_id: str) -> list[dict[str, Any]]:
+    async def get_trade_executions(
+        self,
+        deal_id: str,
+        *,
+        campaign_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Return execution rows for one deal or one sidestep campaign."""
         try:
             normalized_deal_id = str(UUID(str(deal_id)))
         except (TypeError, ValueError):
             return []
 
-        campaign_id = await self._resolve_execution_campaign_id(normalized_deal_id)
         if campaign_id:
+            try:
+                normalized_campaign_id = str(UUID(str(campaign_id)))
+            except (TypeError, ValueError):
+                return []
+            replay_campaign_id = await self._resolve_requested_execution_campaign_id(
+                normalized_campaign_id
+            )
+        else:
+            replay_campaign_id = await self._resolve_execution_campaign_id(
+                normalized_deal_id
+            )
+
+        if replay_campaign_id:
             return await self._execute_db(
-                model.TradeExecutions.filter(campaign_id=campaign_id)
+                model.TradeExecutions.filter(campaign_id=replay_campaign_id)
                 .order_by("timestamp", "id")
                 .values(),
-                f"Error getting trade executions for sidestep campaign {campaign_id}.",
+                "Error getting trade executions for sidestep campaign "
+                f"{replay_campaign_id}.",
                 [],
             )
 
@@ -734,6 +752,13 @@ class Trades:
         if not campaign_id:
             return None
 
+        return await self._resolve_requested_execution_campaign_id(campaign_id)
+
+    async def _resolve_requested_execution_campaign_id(
+        self,
+        campaign_id: str,
+    ) -> str | None:
+        """Return a campaign id when its executions form one replay timeline."""
         campaign_rows = await self._execute_db(
             model.SpotCampaigns.filter(campaign_id=campaign_id)
             .limit(1)

--- a/backend/tests/test_waiting_replay_indicators_regression_1.py
+++ b/backend/tests/test_waiting_replay_indicators_regression_1.py
@@ -1,0 +1,136 @@
+"""Regression coverage for Waiting campaign replay indicators."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import model
+import pytest
+from service import trade_replay_indicators as replay_module
+from service.trade_replay_indicators import (
+    ReplayIndicatorCandle,
+    TradeReplayIndicatorService,
+)
+from service.trades import Trades
+from tortoise import Tortoise
+
+CURRENT_DEAL_ID = "11111111-1111-4111-8111-111111111111"
+PREVIOUS_DEAL_ID = "22222222-2222-4222-8222-222222222222"
+CAMPAIGN_ID = "33333333-3333-4333-8333-333333333333"
+
+
+class _FakeBuilder:
+    """Return a deterministic overlay for the persisted strategy."""
+
+    def __init__(self, symbol: str, timeframe: str) -> None:
+        self.symbol = symbol
+        self.timeframe = timeframe
+
+    async def collect_strategy_requirements(self, *slugs: str) -> list[str]:
+        return list(slugs)
+
+    def required_warmup_candles(self) -> int:
+        return 0
+
+    async def build(
+        self,
+        indicators: Any,
+        candles: list[ReplayIndicatorCandle],
+        replay_start_index: int,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "ema",
+                "label": "EMA 20",
+                "pane": "price",
+                "renderer": "line",
+                "color": "#B7791F",
+                "values": [
+                    {
+                        "time": candles[replay_start_index].timestamp,
+                        "value": 100.0,
+                    }
+                ],
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_waiting_replay_uses_campaign_strategy_when_current_deal_is_empty(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Waiting charts inherit strategy snapshots from prior campaign executions."""
+    monkeypatch.chdir(os.path.join(os.path.dirname(__file__), ".."))
+    db_path = tmp_path / "test.sqlite"
+    await Tortoise.init(db_url=f"sqlite://{db_path}", modules={"models": ["model"]})
+    await Tortoise.generate_schemas()
+
+    await model.SpotCampaigns.create(
+        campaign_id=CAMPAIGN_ID,
+        symbol="BTC/USDC",
+        lifecycle_mode="sidestep_reentry",
+        state="flat_waiting_reentry",
+        started_at="2026-07-01T08:00:00+00:00",
+        last_transition_at="2026-07-02T08:00:00+00:00",
+        current_deal_id=None,
+        sidestep_count=1,
+        tp_percent=5.0,
+        principal_quote=100.0,
+        reserved_quote=105.0,
+        cumulative_realized_quote=5.0,
+        cumulative_realized_percent=5.0,
+        metadata_json="{}",
+    )
+    await model.TradeExecutions.create(
+        deal_id=PREVIOUS_DEAL_ID,
+        campaign_id=CAMPAIGN_ID,
+        symbol="BTC/USDC",
+        side="sell",
+        role="sidestep_exit",
+        timestamp="1782900000000",
+        price=105.0,
+        amount=1.0,
+        ordersize=105.0,
+        strategy_name="ema20_swing",
+        timeframe="1h",
+    )
+
+    service = TradeReplayIndicatorService(Trades())
+
+    async def fake_load_candles(
+        *args: Any,
+        **kwargs: Any,
+    ) -> list[ReplayIndicatorCandle]:
+        return [
+            ReplayIndicatorCandle(
+                timestamp=1_782_900_000_000,
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.0,
+                volume=10.0,
+            )
+        ]
+
+    monkeypatch.setattr(service, "_load_candles", fake_load_candles)
+    monkeypatch.setattr(
+        replay_module,
+        "StrategyChartIndicatorBuilder",
+        _FakeBuilder,
+    )
+
+    payload = await service.get_indicators(
+        CURRENT_DEAL_ID,
+        "1h",
+        1_782_900_000_000,
+        1_782_903_600_000,
+        campaign_id=CAMPAIGN_ID,
+    )
+
+    assert payload["source"] == "execution_ledger"
+    assert payload["strategies"] == ["ema20_swing"]
+    assert payload["indicators"][0]["label"] == "EMA 20"
+
+    await Tortoise.close_connections()

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,8 +124,8 @@ These streams are fan-out based: one producer loop refreshes shared data every
 | --- | --- | --- |
 | `GET` | `/trades/closed/length` | Return the total number of closed trades. |
 | `GET` | `/trades/closed/{page}` | Return one closed-trades page. |
-| `GET` | `/trades/executions/{deal_id}` | Return chronological execution rows for one deal replay. |
-| `GET` | `/trades/replay/indicators/{deal_id}/{timerange}/{start}/{end}` | Return strategy indicator overlays for one bounded trade replay window. |
+| `GET` | `/trades/executions/{deal_id}` | Return chronological execution rows for one deal replay; Waiting clients may add `campaign_id` to span the persisted sidestep campaign. |
+| `GET` | `/trades/replay/indicators/{deal_id}/{timerange}/{start}/{end}` | Return strategy indicator overlays for one bounded trade replay window; Waiting clients may add `campaign_id` to resolve prior campaign strategy snapshots. |
 | `POST` | `/trades/closed/delete/{trade_id}` | Delete a closed trade. |
 | `POST` | `/trades/unsellable/delete/{trade_id}` | Delete an unsellable trade after manual cleanup. |
 | `POST` | `/trades/unsellable/delete/all` | Delete all unsellable trades after manual cleanup. |
@@ -133,6 +133,12 @@ These streams are fan-out based: one producer loop refreshes shared data every
 | `POST` | `/trades/waiting/activate/{campaign_id}` | Force a waiting sidestep campaign back into an active long leg. |
 | `POST` | `/trades/mission/pause/{symbol}` | Pause automation for one open or waiting mission. |
 | `POST` | `/trades/mission/resume/{symbol}` | Resume automation for one open or waiting mission. |
+
+The optional `campaign_id` query parameter on the execution and indicator
+replay endpoints is a read-only Waiting-chart context. Both identifiers must be
+UUIDs. Moonwalker uses the persisted campaign execution ledger only when the
+campaign is a sidestep replay timeline; Open and Closed clients continue using
+the deal-only form.
 
 ## Statistics
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,11 +286,13 @@ When `trade_mode = sidestep` on spot markets:
 
 In the Trades page, open the **Waiting** tab and expand a campaign row with a
 pointer, Enter, or Space to inspect its TradingView replay. The chart shows the
-same buy, re-entry, safety-order, and exit markers used by open and closed
-trades. Older campaigns without complete execution rows fall back to the
-campaign timestamps and recorded waiting exit price instead of hiding the
-chart. Expanding a row is read-only; Stop, Activate, Pause, and Resume remain
-separate confirmed actions.
+same strategy indicators plus buy, re-entry, safety-order, and exit markers
+used by open and closed trades. The Waiting replay resolves indicators from the
+persisted campaign execution timeline even while the current flat deal has no
+executions. Older campaigns without complete execution rows fall back to the
+campaign timestamps and recorded waiting exit price instead of hiding the chart.
+Expanding a row is read-only; Stop, Activate, Pause, and Resume remain separate
+confirmed actions.
 
 ## Autopilot Green Phase
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -129,12 +129,14 @@ Waiting sidestep campaigns use the same TradingView replay language as open and
 closed trades. In the Trades page, select **Waiting** and expand a campaign row
 with a pointer, Enter, or Space. Nested action controls do not toggle the row.
 
-Moonwalker loads the deal's chronological execution history before mounting the
-chart and marks buys, re-entries, safety orders, and exits. If a legacy campaign
-has sparse, malformed, or temporarily unavailable execution history, the chart
-still opens using the campaign timestamps and recorded waiting exit price.
-Replay expansion is read-only and does not activate, stop, pause, or resume a
-campaign.
+Moonwalker loads the persisted campaign's chronological execution history
+before mounting the chart, renders the strategy indicators used by its legs,
+and marks buys, re-entries, safety orders, and exits. This campaign context
+keeps indicators available while the current flat Waiting deal has no
+executions. If a legacy campaign has sparse, malformed, or temporarily
+unavailable execution history, the chart still opens using the campaign
+timestamps and recorded waiting exit price. Replay expansion is read-only and
+does not activate, stop, pause, or resume a campaign.
 
 ## Backup And Restore
 

--- a/frontend/src/components/TradeReplayChart.vue
+++ b/frontend/src/components/TradeReplayChart.vue
@@ -115,6 +115,7 @@ const props = defineProps<{
     startTimestamp: number | string
     endTimestamp?: number | string | null
     dealId?: string | null
+    campaignId?: string | null
     archiveDealId?: string | null
     minTimeframe: TimeframeChoice
     markers: TradeReplayMarker[]
@@ -171,6 +172,15 @@ function toTimestampMs(value: number | string | null | undefined): number | null
     }
     const parsed = Date.parse(String(value))
     return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeUuid(value: string | null | undefined): string | null {
+    const normalized = String(value ?? '').trim()
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        normalized,
+    )
+        ? normalized
+        : null
 }
 
 function normalizeCandleRows(payload: unknown): Array<Record<string, number>> {
@@ -256,14 +266,21 @@ async function loadReplayIndicators(
     historyEnd: number | null,
 ): Promise<void> {
     replayIndicators.value = []
-    const dealId = props.dealId ?? props.archiveDealId
+    const campaignId = normalizeUuid(props.campaignId)
+    const dealId = props.dealId ?? props.archiveDealId ?? campaignId
     if (!dealId) {
         return
     }
     const indicatorEnd = historyEnd ?? Date.now()
+    const campaignQuery = campaignId
+        ? `?campaign_id=${encodeURIComponent(campaignId)}`
+        : ''
     try {
+        const indicatorUrl =
+            `/trades/replay/indicators/${dealId}/` +
+            `${timeframe.timerange}/${historyStart}/${indicatorEnd}`
         const payload = await fetchJson<ReplayIndicatorResponse>(
-            `/trades/replay/indicators/${dealId}/${timeframe.timerange}/${historyStart}/${indicatorEnd}`,
+            `${indicatorUrl}${campaignQuery}`,
         )
         replayIndicators.value = Array.isArray(payload.result?.indicators)
             ? payload.result.indicators

--- a/frontend/src/components/WaitingCampaignExpandedRow.vue
+++ b/frontend/src/components/WaitingCampaignExpandedRow.vue
@@ -6,6 +6,7 @@
         :precision="Number(props.rowData.precision ?? 0)"
         :start-timestamp="replayStartTimestamp"
         :deal-id="props.rowData.deal_id"
+        :campaign-id="campaignId"
         :min-timeframe="props.minTimeframe"
         :markers="chartMarkers"
         :price-lines="chartPriceLines"
@@ -32,8 +33,21 @@ const BUY_MARKER_COLOR = '#2E7D5B'
 const BUY_LINE_COLOR = '#1D5C49'
 const SELL_MARKER_COLOR = '#B4443F'
 
+function normalizeUuid(value: string | null | undefined): string | null {
+    const normalized = String(value ?? '').trim()
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        normalized,
+    )
+        ? normalized
+        : null
+}
+
+const campaignId = computed(() => normalizeUuid(props.rowData.campaign_id))
+const replayIdentity = computed(
+    () => props.rowData.deal_id ?? campaignId.value,
+)
 const executions = ref<TradeExecutionRow[]>([])
-const executionHistoryResolved = ref(!props.rowData.deal_id)
+const executionHistoryResolved = ref(!replayIdentity.value)
 const chartReady = computed(() => executionHistoryResolved.value)
 
 function executionTimestampMs(timestamp: string): number {
@@ -205,13 +219,21 @@ const chartPriceLines = computed(() => {
 })
 
 async function loadExecutions(): Promise<void> {
-    if (!props.rowData.deal_id) {
+    if (!replayIdentity.value) {
         executionHistoryResolved.value = true
         return
     }
+    const campaignQuery = campaignId.value
+        ? `?campaign_id=${encodeURIComponent(campaignId.value)}`
+        : ''
     try {
+        const dealExecutionsUrl =
+            `/trades/executions/${props.rowData.deal_id}`
+        const executionUrl = props.rowData.deal_id
+            ? dealExecutionsUrl
+            : `/trades/executions/${replayIdentity.value}`
         const response = await fetchJson<{ result: TradeExecutionRow[] }>(
-            `/trades/executions/${props.rowData.deal_id}`,
+            `${executionUrl}${campaignQuery}`,
         )
         executions.value = Array.isArray(response.result)
             ? response.result

--- a/frontend/tests-vitest/waiting-campaign-indicators.regression-1.test.ts
+++ b/frontend/tests-vitest/waiting-campaign-indicators.regression-1.test.ts
@@ -1,0 +1,87 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import WaitingCampaignExpandedRow from '../src/components/WaitingCampaignExpandedRow.vue'
+import type { WaitingCampaignRow } from '../src/stores/trades'
+
+const fetchJsonMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../src/api/client', () => ({
+    fetchJson: fetchJsonMock,
+}))
+
+const CAMPAIGN_ID = '33333333-3333-4333-8333-333333333333'
+const DEAL_ID = '11111111-1111-4111-8111-111111111111'
+
+const TradeReplayChartStub = defineComponent({
+    name: 'TradeReplayChartStub',
+    props: {
+        campaignId: { type: String, default: null },
+    },
+    setup: () => () => h('div', { 'data-test': 'replay-chart' }),
+})
+
+function waitingRow(): WaitingCampaignRow {
+    return {
+        id: 7,
+        key: 7,
+        symbol: 'BTC/USDC',
+        deal_id: DEAL_ID,
+        campaign_id: CAMPAIGN_ID,
+        campaign_started_at: '2026-07-01T10:00:00Z',
+        lifecycle_mode: 'sidestep_reentry',
+        exposure_state: 'flat_waiting_reentry',
+        amount: 0,
+        cost: 0,
+        profit: 0,
+        profit_percent: 0,
+        current_price: 98,
+        tp_price: 0,
+        avg_price: 0,
+        so_count: 0,
+        open_date: '2026-07-01T09:00:00Z',
+        baseorder: {
+            id: 1,
+            timestamp: '2026-07-01T09:00:00Z',
+            ordersize: 100,
+            amount: 1,
+            symbol: 'BTC/USDC',
+            price: 100,
+        },
+        safetyorder: [],
+        precision: 2,
+        waiting_reference_price: 101,
+        last_transition_at: '2026-07-01T12:00:00Z',
+    }
+}
+
+describe('Waiting campaign replay indicators', () => {
+    beforeEach(() => {
+        fetchJsonMock.mockReset()
+        fetchJsonMock.mockResolvedValue({ result: [] })
+    })
+
+    it('passes campaign context to execution and indicator replay', async () => {
+        const wrapper = mount(WaitingCampaignExpandedRow, {
+            props: {
+                rowData: waitingRow(),
+                minTimeframe: { timerange: '15min', seconds: 900 },
+            },
+            global: {
+                stubs: {
+                    TradeReplayChart: TradeReplayChartStub,
+                },
+            },
+        })
+
+        await flushPromises()
+
+        expect(fetchJsonMock).toHaveBeenCalledWith(
+            `/trades/executions/${DEAL_ID}?campaign_id=${CAMPAIGN_ID}`,
+        )
+        expect(
+            wrapper.getComponent(TradeReplayChartStub).props('campaignId'),
+        ).toBe(CAMPAIGN_ID)
+    })
+})


### PR DESCRIPTION
## Summary

- pass the Waiting campaign UUID as read-only replay context
- resolve prior sidestep campaign executions when the current flat deal has no ledger rows
- render the same persisted strategy overlays used by Open and Closed replays
- document the optional replay query context and add backend/frontend regressions

## Root cause

Waiting requested indicators with only its current deal ID. Flat Waiting deals can have no execution rows, so the backend could not resolve a symbol or persisted strategy and returned empty indicator and strategy arrays.

## Verification

- cd scripts && ./ci.sh
- 745 backend tests passed
- 378 legacy frontend tests passed
- 39 rendered frontend tests passed
- formatting, lint, import sorting, mypy, frontend type checking, coverage ratchets, and production build passed
- Python and npm vulnerability audits passed
- npm registry signatures and attestations passed

## Runtime safety

- reproduced read-only against http://192.168.6.5:8140
- did not click Activate, Stop, More, Resolve, or any other action control
- did not trade or change runtime configuration
- did not restart or replace the live trading instance for an after screenshot